### PR TITLE
Remove all use of backticks as they are considerd bad practice.

### DIFF
--- a/code_quality.md
+++ b/code_quality.md
@@ -25,8 +25,8 @@ function New-Credential
     New-Object PSCredential -ArgumentList $User, $SecPass
 }
 
-PS> Invoke-ScriptAnalyzer .\New-Credential.ps1 `
-    | Select-Object -ExpandProperty RuleName
+PS> Invoke-ScriptAnalyzer .\New-Credential.ps1 |
+    Select-Object -ExpandProperty RuleName
 PSAvoidUsingUserNameAndPassWordParams
 PSAvoidUsingConvertToSecureStringWithPlainText
 PSAvoidUsingPlainTextForPassword
@@ -74,13 +74,13 @@ Invoke-ScriptAnalyzer .\New-Credential.ps1 -SuppressedOnly
 
 Describe 'New-Credential' {
     It 'Produces PSCredential object' {
-        New-Credential -User a -Pass b `
-            | Should BeOfType PSCredential
+        New-Credential -User a -Pass b |
+            Should BeOfType PSCredential
     }
     It 'Embed correct user' {
-        New-Credential -User a -Pass b `
-            | Select-Object -ExpandProperty UserName `
-            | Should Be 'a'
+        New-Credential -User a -Pass b |
+            Select-Object -ExpandProperty UserName |
+            Should Be 'a'
     }
 }
 ```

--- a/line_breaks.md
+++ b/line_breaks.md
@@ -6,18 +6,20 @@ Break lines at 70 characters
 
 Configure your editor to replace a tabstop with four spaces
 
-Use the backtick (`) to break a line
+Do not use the backtick (`) to break a line, use one of the other [line continuation characters](https://get-powershellblog.blogspot.co.uk/2017/07/bye-bye-backtick-natural-line.html) instead
 
 --
 
 ## Break long lines
 
-Break at parameters and indent:
+Break at operators and indent:
 
 ```powershell
-Get-ChildItem `
-    -Path c:\ `
-    -Recurse
+if ($InputObject -eq 'ThisValue' -or
+    $InputObject -eq 'OtherValue')
+{
+    Do-Something
+}
 ```
 
 --
@@ -27,8 +29,8 @@ Get-ChildItem `
 Break at pipeline steps and indent:
 
 ```powershell
-Get-ChildItem -Path c:\ -Recurse `
-    | Select-Object -First 10
+Get-ChildItem -Path c:\ -Recurse |
+    Select-Object -First 10
 ```
 
 --

--- a/oneliners.md
+++ b/oneliners.md
@@ -14,10 +14,10 @@ Avoid scriptblocks in a pipeline:
 
 ```powershell
 # this is bad
-Get-ChildItem `
-    | Select-Object -First 10 `
-    | ForEach-Object { $_.FullName } `
-    | Where-Object { $_ -like '*.exe' }
+Get-ChildItem |
+    Select-Object -First 10 |
+    ForEach-Object { $_.FullName } |
+    Where-Object { $_ -like '*.exe' }
 
 # this is good
 $FilesTop10 = Get-ChildItem | Select-Object -First 10

--- a/output.md
+++ b/output.md
@@ -21,7 +21,7 @@ PowerShell supports several stream for different types of information:
 
 Avoid `Write-Host` because it does not add to a stream
 
-Output is directly sent to the console to display
+`Write-Host` Output is only sent to the console to display, if no console is there (such as running in a background process) then no output is displayed
 
 --
 
@@ -50,9 +50,7 @@ Write-Information 'message'
 Capturing the information stream:
 
 ```powershell
-Get-ChildItem `
-    -InformationAction Continue `
-    -InformationVariable InfoStream
+Get-ChildItem -InformationAction Continue -InformationVariable InfoStream
 $InfoStream
 ```
 

--- a/pipelines.md
+++ b/pipelines.md
@@ -120,11 +120,11 @@ function Do-Something
 `-OutVariable` can be used to obtain result of individual steps:
 
 ```powershell
-Get-ChildItem -OutVariable gci `
-    | Where-Object { Length -ne $null } -OutVariable where `
-    | Group-Object -Property Extension -OutVariable group `
-    | Sort-Object -Property Count -OutVariable sort `
-    | Select-Object -Last 1
+Get-ChildItem -OutVariable gci |
+    Where-Object { Length -ne $null } -OutVariable where |
+    Group-Object -Property Extension -OutVariable group |
+    Sort-Object -Property Count -OutVariable sort |
+    Select-Object -Last 1
 ```
 
 A single execution suffices to debug all steps of the pipeline


### PR DESCRIPTION
Replace with splatting and ending lines with other characters like pipes. Included a link to the article by Mark Kraus discussing the other options available for line continuation: https://get-powershellblog.blogspot.co.uk/2017/07/bye-bye-backtick-natural-line.html