### PR TITLE
Fixes to comply with best practice and latest module versions

### DIFF
--- a/caveats.md
+++ b/caveats.md
@@ -98,6 +98,7 @@ Use the following instead to throw:
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/code_quality.md
+++ b/code_quality.md
@@ -75,12 +75,12 @@ Invoke-ScriptAnalyzer .\New-Credential.ps1 -SuppressedOnly
 Describe 'New-Credential' {
     It 'Produces PSCredential object' {
         New-Credential -User a -Pass b `
-            | Should BeOfType PSCredential
+            | Should -BeOfType PSCredential
     }
     It 'Embed correct user' {
         New-Credential -User a -Pass b `
             | Select-Object -ExpandProperty UserName `
-            | Should Be 'a'
+            | Should -Be 'a'
     }
 }
 ```

--- a/functions.md
+++ b/functions.md
@@ -116,13 +116,14 @@ function Do-Something
 
         [Parameter(ParameterSetName='ByObject')]
         [object]$Object,
-        [Parameter(ParameterSetName='ById')]
-        [Parameter(ParameterSetName='ByObject')]
+
         [switch]$PassThru
     )
     if ($PSCmdlet.ParameterSetName -ieq 'ByObject') {}
 }
 ```
+
+Parameters which aren't declared as members of a specific ParameterSet are assumed to be members of all ParameterSets.
 
 --
 

--- a/functions.md
+++ b/functions.md
@@ -15,6 +15,7 @@ Use integrated parameter validation
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -52,7 +53,7 @@ Supported [keywords in comment based help](https://docs.microsoft.com/en-us/powe
 
 ## Advanced functions
 
-Promote to cmdlet because...
+Promote to advanced function because...
 
 - Advanced feature like [ShouldProcess](#/shouldprocess) and `-WhatIf` and `-Confirm`
 
@@ -108,9 +109,11 @@ Functions can accept multiple sets of parameters
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter(ParameterSetName='ById')]
         [int]$Id,
+
         [Parameter(ParameterSetName='ByObject')]
         [object]$Object,
         [Parameter(ParameterSetName='ById')]
@@ -191,6 +194,7 @@ Functions are expose by `Function:\`
 
 ```powershell
 $Code = {
+    [cmdletbinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -219,6 +223,7 @@ I recommend to use [`New-DynamicParameter`](https://github.com/beatcracker/Power
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     DynamicParam {
         @(
             [psobject]@{
@@ -241,6 +246,7 @@ function Do-Something
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     DynamicParam {
         #...
     }

--- a/pipelines.md
+++ b/pipelines.md
@@ -25,6 +25,7 @@ Get-ChildItem | Remove-Item
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter(ValueFromPipeline)]
         [string[]]
@@ -75,6 +76,7 @@ Instead of using two [parameter sets](#/parameter_sets), extract the parameter f
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter(Mandatory,
             ValueFromPipeline,
@@ -97,6 +99,7 @@ By using an parameter alias, you can retrieve a different property:
 ```powershell
 function Do-Something
 {
+    [cmdletbinding()]
     param(
         [Parameter(Mandatory,
             ValueFromPipeline,


### PR DESCRIPTION
This could probably be broken into 3 different PRs, and I will do that if required, but I just found a few things that needed fixing and decided to lump them all together.

The Pester fix is minor but is the way to provide assertions to 4.x+ versions of Pester, the previous method still works but the new way is clearer and more adaptable.

The ParameterSet fix is to make it easier to read and added a note to make people aware that any parameter not declared as a member of a parameter set is a member of all parameter sets.

The cmdletbinding fix might be the most wide ranging but discussions we had on the best practice repo and consensus seemed to be that for almost all cases [cmdletbinding()] should be declared for a function. There are cases where you don't want that extra functionality but those should be the exception and the choice should be made carefully by the developer due to the differences it can cause.